### PR TITLE
Relax the activesupport dependency

### DIFF
--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pronto-flay', '~> 0.9.0' if RUBY_PLATFORM != 'java'
   s.add_development_dependency 'vcr'
 
-  s.add_dependency 'activesupport', '~> 4.2.9'
+  s.add_dependency 'activesupport', '> 4.2.9', '< 5.2'
   s.add_dependency 'aws-sdk-s3', '~> 1.16'
   s.add_dependency 'docile', '~> 1.1'
   s.add_dependency 'erubis', '~> 2.7'


### PR DESCRIPTION
The ActiveSupport version specification is too restrictive, it makes impossible to use the gem with Rails 5.
This PR relax the dependency to make the gem Rails 5 compatible.